### PR TITLE
Added health checks

### DIFF
--- a/api/controllers/health_controller.go
+++ b/api/controllers/health_controller.go
@@ -30,7 +30,7 @@ func (c *HealthController) RegisterRoutes(router *gin.Engine) {
 }
 
 func (c *HealthController) getHealth(ctx *gin.Context) {
-	c.handleHealthCheck(ctx, c.healthService.CheckReadiness)
+	c.handleHealthCheck(ctx, c.healthService.CheckHealth)
 }
 
 func (c *HealthController) getLiveness(ctx *gin.Context) {

--- a/api/controllers/health_controller.go
+++ b/api/controllers/health_controller.go
@@ -1,0 +1,65 @@
+package controllers
+
+import (
+	"context"
+	"net/http"
+
+	responses "github.com/PTSS-Support/identity-service/api/dtos/responses/health"
+	"github.com/PTSS-Support/identity-service/core/services"
+	HealthStatus "github.com/PTSS-Support/identity-service/domain/enums"
+	"github.com/gin-gonic/gin"
+)
+
+type HealthController struct {
+	healthService *services.HealthService
+}
+
+type healthCheck func(ctx context.Context) (*responses.HealthResponse, error)
+
+// Due to this being a standardized, never-changing endpoint, we don't need a facade layer, this will only add unnecessary code to maintain.
+func NewHealthController(healthService *services.HealthService) *HealthController {
+	return &HealthController{
+		healthService: healthService,
+	}
+}
+
+func (c *HealthController) RegisterRoutes(router *gin.Engine) {
+	router.GET("/q/health", c.getHealth)
+	router.GET("/q/health/live", c.getLiveness)
+	router.GET("/q/health/ready", c.getReadiness)
+}
+
+func (c *HealthController) getHealth(ctx *gin.Context) {
+	c.handleHealthCheck(ctx, c.healthService.CheckReadiness)
+}
+
+func (c *HealthController) getLiveness(ctx *gin.Context) {
+	c.handleHealthCheck(ctx, c.healthService.CheckLiveness)
+}
+
+func (c *HealthController) getReadiness(ctx *gin.Context) {
+	c.handleHealthCheck(ctx, c.healthService.CheckReadiness)
+}
+
+func (c *HealthController) handleHealthCheck(ctx *gin.Context, check healthCheck) {
+	response, err := check(ctx)
+	if err != nil {
+		ctx.JSON(http.StatusServiceUnavailable, responses.HealthResponse{
+			Status: HealthStatus.StatusDown,
+			Checks: []responses.Check{{
+				Name:   "Health check error",
+				Status: HealthStatus.StatusDown,
+				Data: map[string]interface{}{
+					"error": err.Error(),
+				},
+			}},
+		})
+		return
+	}
+
+	statusCode := http.StatusOK
+	if response.Status == HealthStatus.StatusDown {
+		statusCode = http.StatusServiceUnavailable
+	}
+	ctx.JSON(statusCode, response)
+}

--- a/api/dtos/responses/health/health_response.go
+++ b/api/dtos/responses/health/health_response.go
@@ -1,0 +1,16 @@
+package requests
+
+import (
+	"github.com/PTSS-Support/identity-service/domain/enums"
+)
+
+type Check struct {
+	Name   string                 `json:"name"`
+	Status enums.HealthStatus     `json:"status"`
+	Data   map[string]interface{} `json:"data,omitempty"`
+}
+
+type HealthResponse struct {
+	Status enums.HealthStatus `json:"status"`
+	Checks []Check            `json:"checks"`
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,6 +21,11 @@ func main() {
 	// Initialize dependencies
 	baseKeycloakRepo := repositories.NewBaseKeycloakRepository(&cfg.Keycloak)
 
+	// Health
+	healthRepo := repositories.NewHealthRepository(baseKeycloakRepo)
+	healthService := services.NewHealthService(healthRepo)
+	healthController := controllers.NewHealthController(healthService)
+
 	// Auth
 	authRepo := repositories.NewAuthRepository(baseKeycloakRepo)
 	authService := services.NewAuthService(authRepo)
@@ -58,14 +63,7 @@ func main() {
 	// Register routes
 	authController.RegisterRoutes(r)
 	identityController.RegisterRoutes(r)
-
-	// Health check endpoint
-	r.GET("/health", func(c *gin.Context) {
-		c.JSON(200, gin.H{
-			"status":  "healthy",
-			"version": "1.0.0",
-		})
-	})
+	healthController.RegisterRoutes(r)
 
 	// Start server
 	if err := r.Run(":" + cfg.Server.Port); err != nil {

--- a/core/services/health_service.go
+++ b/core/services/health_service.go
@@ -1,0 +1,61 @@
+package services
+
+import (
+	"context"
+
+	responses "github.com/PTSS-Support/identity-service/api/dtos/responses/health"
+	HealthStatus "github.com/PTSS-Support/identity-service/domain/enums"
+	"github.com/PTSS-Support/identity-service/infrastructure/repositories"
+	"github.com/PTSS-Support/identity-service/infrastructure/util"
+)
+
+type HealthService struct {
+	healthRepo repositories.HealthRepository
+	logger     util.Logger
+}
+
+func NewHealthService(healthRepo repositories.HealthRepository) *HealthService {
+	return &HealthService{
+		healthRepo: healthRepo,
+		logger:     util.NewLogger("HealthService"),
+	}
+}
+
+func (s *HealthService) CheckReadiness(ctx context.Context) (*responses.HealthResponse, error) {
+	keycloakHealth, err := s.healthRepo.CheckHealth(ctx)
+
+	if err != nil {
+		return &responses.HealthResponse{
+			Status: HealthStatus.StatusDown,
+			Checks: []responses.Check{
+				{
+					Name:   "Keycloak health check",
+					Status: HealthStatus.StatusDown,
+					Data: map[string]interface{}{
+						"error": err.Error(),
+					},
+				},
+			},
+		}, nil
+	}
+
+	return &responses.HealthResponse{
+		Status: HealthStatus.StatusUp,
+		Checks: []responses.Check{
+			{
+				Name:   "Keycloak health check",
+				Status: HealthStatus.StatusUp,
+				Data: map[string]interface{}{
+					"response": keycloakHealth,
+				},
+			},
+		},
+	}, nil
+}
+
+func (s *HealthService) CheckLiveness(ctx context.Context) (*responses.HealthResponse, error) {
+	return &responses.HealthResponse{
+		Status: HealthStatus.StatusUp,
+		Checks: []responses.Check{},
+	}, nil
+}

--- a/core/services/health_service.go
+++ b/core/services/health_service.go
@@ -21,6 +21,34 @@ func NewHealthService(healthRepo repositories.HealthRepository) *HealthService {
 	}
 }
 
+func (s *HealthService) CheckHealth(ctx context.Context) (*responses.HealthResponse, error) {
+	// Get liveness check
+	livenessResp, err := s.CheckLiveness(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get readiness check
+	readinessResp, err := s.CheckReadiness(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Combine the checks
+	combinedResponse := &responses.HealthResponse{
+		Status: HealthStatus.StatusUp,
+		Checks: append(livenessResp.Checks, readinessResp.Checks...),
+	}
+
+	// If either check is down, mark overall status as down
+	if livenessResp.Status == HealthStatus.StatusDown ||
+		readinessResp.Status == HealthStatus.StatusDown {
+		combinedResponse.Status = HealthStatus.StatusDown
+	}
+
+	return combinedResponse, nil
+}
+
 func (s *HealthService) CheckReadiness(ctx context.Context) (*responses.HealthResponse, error) {
 	keycloakHealth, err := s.healthRepo.CheckHealth(ctx)
 

--- a/domain/enums/health_status.go
+++ b/domain/enums/health_status.go
@@ -1,0 +1,8 @@
+package enums
+
+type HealthStatus string
+
+const (
+	StatusUp   HealthStatus = "UP"
+	StatusDown HealthStatus = "DOWN"
+)

--- a/infrastructure/repositories/health_repository.go
+++ b/infrastructure/repositories/health_repository.go
@@ -1,0 +1,82 @@
+package repositories
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	responses "github.com/PTSS-Support/identity-service/api/dtos/responses/health"
+	HealthStatus "github.com/PTSS-Support/identity-service/domain/enums"
+)
+
+type HealthRepository interface {
+	CheckHealth(ctx context.Context) (*responses.HealthResponse, error)
+}
+
+type healthRepository struct {
+	*BaseKeycloakRepository
+}
+
+func NewHealthRepository(keycloak *BaseKeycloakRepository) HealthRepository {
+	return &healthRepository{
+		BaseKeycloakRepository: keycloak,
+	}
+}
+
+func (r *healthRepository) CheckHealth(ctx context.Context) (*responses.HealthResponse, error) {
+	log := r.logger.WithContext(ctx)
+	healthURL := fmt.Sprintf("%s/health/ready", r.config.BaseURL)
+
+	resp, err := r.makeJSONRequest(ctx, http.MethodGet, healthURL, nil)
+	if err != nil {
+		log.Error("Failed to check Keycloak health", "error", err)
+		return &responses.HealthResponse{
+			Status: HealthStatus.StatusDown,
+			Checks: []responses.Check{{
+				Name:   "Keycloak health check",
+				Status: HealthStatus.StatusDown,
+				Data: map[string]interface{}{
+					"error":     err.Error(),
+					"<default>": "DOWN",
+				},
+			}},
+		}, nil
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Error("Failed to read health response body", "error", err)
+		return &responses.HealthResponse{
+			Status: HealthStatus.StatusDown,
+			Checks: []responses.Check{{
+				Name:   "Keycloak health check",
+				Status: HealthStatus.StatusDown,
+				Data: map[string]interface{}{
+					"error":     fmt.Sprintf("failed to read health response: %v", err),
+					"<default>": "DOWN",
+				},
+			}},
+		}, nil
+	}
+
+	var healthResponse responses.HealthResponse
+	if err := json.Unmarshal(body, &healthResponse); err != nil {
+		log.Error("Failed to parse health response", "error", err)
+		return &responses.HealthResponse{
+			Status: HealthStatus.StatusDown,
+			Checks: []responses.Check{{
+				Name:   "Keycloak health check",
+				Status: HealthStatus.StatusDown,
+				Data: map[string]interface{}{
+					"error":     fmt.Sprintf("failed to parse health response: %v", err),
+					"<default>": "DOWN",
+				},
+			}},
+		}, nil
+	}
+
+	return &healthResponse, nil
+}


### PR DESCRIPTION
This is the format of the response: 
```json
{
  "status": "UP", // The overall health status of the system, typically either "UP" or "DOWN".
  "checks": [ // A list of individual health checks for various components or services.
    {
      "name": "Keycloak health check", // The name of the health check, indicating the specific component or service being checked.
      "status": "UP", // The health status of this particular check, either "UP" or "DOWN".
      "data": { // Additional data related to this health check.

      }
    }
  ]
}

```

This was inspired by [smallrye-health](https://quarkus.io/guides/smallrye-health) from Quarkus. Just like [smallrye-health](https://quarkus.io/guides/smallrye-health), it provides the following endpoints:
```yaml
/q/health:       // Overall health status, combining all checks.
/q/health/live:  // Liveness status, checks if the app is running.
/q/health/ready: // Readiness status, checks if the app is ready to handle traffic.
```