### PR TITLE
made it so email_verified, preferred_username, email and realm_access…

### DIFF
--- a/keycloak-init.sh
+++ b/keycloak-init.sh
@@ -293,6 +293,7 @@ fi
 
 
 # removing the default scopes
+# email scope
 EMAIL_SCOPE_ID=$(curl -H "Authorization: Bearer $TOKEN" \
     "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/client-scopes" \
     | jq -r '.[] | select(.name=="email") | .id')

--- a/keycloak-init.sh
+++ b/keycloak-init.sh
@@ -156,25 +156,6 @@ if [ "$CLIENT_EXISTS" = "0" ]; then
         }' \
         "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/client-scopes/${SCOPE_ID}/protocol-mappers/models"
 
-    # Add email exclusion mapper
-    curl -X POST \
-        -H "Authorization: Bearer $TOKEN" \
-        -H "Content-Type: application/json" \
-        -d '{
-            "name": "exclude-email",
-            "protocol": "openid-connect",
-            "protocolMapper": "oidc-usermodel-property-mapper",
-            "config": {
-                "user.attribute": "email",
-                "claim.name": "email",
-                "jsonType.label": "String",
-                "id.token.claim": "false",
-                "access.token.claim": "false",
-                "userinfo.token.claim": "false"
-            }
-        }' \
-        "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/client-scopes/${SCOPE_ID}/protocol-mappers/models"
-
     # Assign scope to client
     curl -X PUT \
         -H "Authorization: Bearer $TOKEN" \

--- a/keycloak-init.sh
+++ b/keycloak-init.sh
@@ -97,6 +97,9 @@ if [ "$CLIENT_EXISTS" = "0" ]; then
 
     echo "Client created!"
 
+    CLIENT_UUID=$(curl -H "Authorization: Bearer $TOKEN" \
+        "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/clients?clientId=${KEYCLOAK_CLIENT_ID}" | jq -r '.[0].id')
+
     # Create user-details client scope
     echo "Creating client scope..."
     curl -X POST \
@@ -153,6 +156,25 @@ if [ "$CLIENT_EXISTS" = "0" ]; then
         }' \
         "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/client-scopes/${SCOPE_ID}/protocol-mappers/models"
 
+    # Add email exclusion mapper
+    curl -X POST \
+        -H "Authorization: Bearer $TOKEN" \
+        -H "Content-Type: application/json" \
+        -d '{
+            "name": "exclude-email",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-property-mapper",
+            "config": {
+                "user.attribute": "email",
+                "claim.name": "email",
+                "jsonType.label": "String",
+                "id.token.claim": "false",
+                "access.token.claim": "false",
+                "userinfo.token.claim": "false"
+            }
+        }' \
+        "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/client-scopes/${SCOPE_ID}/protocol-mappers/models"
+
     # Assign scope to client
     curl -X PUT \
         -H "Authorization: Bearer $TOKEN" \
@@ -166,6 +188,13 @@ fi
 echo "Getting client UUID..."
 CLIENT_UUID=$(curl -H "Authorization: Bearer $TOKEN" \
     "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/clients?clientId=${KEYCLOAK_CLIENT_ID}" | jq -r '.[0].id')
+
+
+# Finally assign scope to client
+curl -X PUT \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/clients/${CLIENT_UUID}/default-client-scopes/${SCOPE_ID}"
 
 if [ "$CLIENT_EXISTS" = "0" ]; then
     echo "Getting client secret..."
@@ -281,6 +310,42 @@ else
     echo "Admin user already exists, skipping creation..."
 fi
 
+
+# removing the default scopes
+EMAIL_SCOPE_ID=$(curl -H "Authorization: Bearer $TOKEN" \
+    "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/client-scopes" \
+    | jq -r '.[] | select(.name=="email") | .id')
+
+if [ -n "$EMAIL_SCOPE_ID" ]; then
+    echo "Removing email scope from client..."
+    curl -X DELETE \
+        -H "Authorization: Bearer $TOKEN" \
+        "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/clients/${CLIENT_UUID}/default-client-scopes/${EMAIL_SCOPE_ID}"
+fi
+
+# Remove profile scope (contains preferred_username)
+PROFILE_SCOPE_ID=$(curl -H "Authorization: Bearer $TOKEN" \
+    "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/client-scopes" \
+    | jq -r '.[] | select(.name=="profile") | .id')
+
+if [ -n "$PROFILE_SCOPE_ID" ]; then
+    echo "Removing profile scope from client..."
+    curl -X DELETE \
+        -H "Authorization: Bearer $TOKEN" \
+        "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/clients/${CLIENT_UUID}/default-client-scopes/${PROFILE_SCOPE_ID}"
+fi
+
+# Remove roles scope (contains realm_access)
+ROLES_SCOPE_ID=$(curl -H "Authorization: Bearer $TOKEN" \
+    "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/client-scopes" \
+    | jq -r '.[] | select(.name=="roles") | .id')
+
+if [ -n "$ROLES_SCOPE_ID" ]; then
+    echo "Removing roles scope from client..."
+    curl -X DELETE \
+        -H "Authorization: Bearer $TOKEN" \
+        "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/clients/${CLIENT_UUID}/default-client-scopes/${ROLES_SCOPE_ID}"
+fi
 
 # Setup service account permissions
 echo "Setting up service account permissions..."


### PR DESCRIPTION
… are removed from jwt.

made jwt structure cleaner.
now looks like:

```
{
  "exp": 1735327386,
  "iat": 1735327086,
  "jti": "3356f107-d4c1-40a6-ba88-fa27620d522e",
  "iss": "http://localhost:8080/realms/ptss-support",
  "sub": "0125e211-b545-4ab5-b569-9cd110a76fe8",
  "typ": "Bearer",
  "azp": "authentication-service",
  "session_state": "2bb7965d-3941-4cd2-9b8d-a47d231f1b2a",
  "acr": "1",
  "allowed-origins": [
    "*"
  ],
  "scope": "openid user-details",
  "sid": "2bb7965d-3941-4cd2-9b8d-a47d231f1b2a",
  "user_id": "0125e211-b545-4ab5-b569-9cd110a76fe8",
  "roles": [
    "patient",
    "offline_access",
    "default-roles-ptss-support",
    "uma_authorization"
  ]
}
```