### PR TITLE
Feature/add has pin point

### DIFF
--- a/api/dtos/requests/identity/create_identity_request.go
+++ b/api/dtos/requests/identity/create_identity_request.go
@@ -8,7 +8,7 @@ type CreateIdentityRequest struct {
 	Email     string     `json:"email" binding:"required,email,min=6,max=254"`
 	Password  string     `json:"password" binding:"required,min=8,max=128"`
 	Role      enums.Role `json:"role" binding:"required,oneof=admin family_member primary_relative patient healthcare_professional"`
-	GroupID   string     `json:"groupId" validate:"required,uuid"`
-	FirstName string     `json:"firstName" validate:"required"`
-	LastName  string     `json:"lastName" validate:"required"`
+	GroupID   string     `json:"groupId" binding:"required,uuid"`
+	FirstName string     `json:"firstName" binding:"required"`
+	LastName  string     `json:"lastName" binding:"required"`
 }

--- a/api/dtos/requests/identity/create_identity_request.go
+++ b/api/dtos/requests/identity/create_identity_request.go
@@ -8,7 +8,7 @@ type CreateIdentityRequest struct {
 	Email     string     `json:"email" binding:"required,email,min=6,max=254"`
 	Password  string     `json:"password" binding:"required,min=8,max=128"`
 	Role      enums.Role `json:"role" binding:"required,oneof=admin family_member primary_relative patient healthcare_professional"`
-	GroupID   string     `json:"groupId" binding:"required,uuid"`
+	GroupID   string     `json:"groupId" binding:"uuid"`
 	FirstName string     `json:"firstName" binding:"required"`
 	LastName  string     `json:"lastName" binding:"required"`
 }

--- a/api/dtos/requests/identity/create_identity_request.go
+++ b/api/dtos/requests/identity/create_identity_request.go
@@ -5,7 +5,10 @@ import (
 )
 
 type CreateIdentityRequest struct {
-	Email    string     `json:"email" binding:"required,email,min=6,max=254"`
-	Password string     `json:"password" binding:"required,min=8,max=128"`
-	Role     enums.Role `json:"role" binding:"required,oneof=admin family_member primary_relative patient healthcare_professional"`
+	Email     string     `json:"email" binding:"required,email,min=6,max=254"`
+	Password  string     `json:"password" binding:"required,min=8,max=128"`
+	Role      enums.Role `json:"role" binding:"required,oneof=admin family_member primary_relative patient healthcare_professional"`
+	GroupID   string     `json:"groupId" validate:"required,uuid"`
+	FirstName string     `json:"firstName" validate:"required"`
+	LastName  string     `json:"lastName" validate:"required"`
 }

--- a/api/dtos/requests/identity/create_identity_request.go
+++ b/api/dtos/requests/identity/create_identity_request.go
@@ -8,7 +8,7 @@ type CreateIdentityRequest struct {
 	Email     string     `json:"email" binding:"required,email,min=6,max=254"`
 	Password  string     `json:"password" binding:"required,min=8,max=128"`
 	Role      enums.Role `json:"role" binding:"required,oneof=admin family_member primary_relative patient healthcare_professional"`
-	GroupID   string     `json:"groupId" binding:"uuid"`
+	GroupID   string     `json:"groupId" binding:"omitempty,uuid"`
 	FirstName string     `json:"firstName" binding:"required"`
 	LastName  string     `json:"lastName" binding:"required"`
 }

--- a/core/services/identity_service.go
+++ b/core/services/identity_service.go
@@ -39,11 +39,13 @@ func NewIdentityService(identityRepo repositories.IdentityRepository) IdentitySe
 
 func (s *identityService) CreateIdentity(ctx context.Context, req *requests.CreateIdentityRequest, hashedPassword string) (*responses.IdentityResponse, error) {
 	log := s.logger.WithContext(ctx)
-	log.Info("Creating new identity", "email", req.Email, "role", req.Role)
+	sanitizedRole := strings.ReplaceAll(req.Role, "\n", "")
+	sanitizedRole = strings.ReplaceAll(sanitizedRole, "\r", "")
+	log.Info("Creating new identity", "email", req.Email, "role", sanitizedRole)
 
 	if req.Role != enums.RoleHealthcareProfessional && req.Role != enums.RoleAdmin {
 		if req.GroupID == "" {
-			log.Error("GroupID is required for this role", "role", req.Role)
+			log.Error("GroupID is required for this role", "role", sanitizedRole)
 			return nil, errors.ErrGroupIDRequired
 		}
 	}

--- a/core/services/identity_service.go
+++ b/core/services/identity_service.go
@@ -43,8 +43,11 @@ func (s *identityService) CreateIdentity(ctx context.Context, req *requests.Crea
 
 	// Create domain model
 	identity := &models.Identity{
-		Email: req.Email,
-		Role:  req.Role,
+		Email:     req.Email,
+		Role:      req.Role,
+		GroupID:   req.GroupID,
+		FirstName: req.FirstName,
+		LastName:  req.LastName,
 	}
 
 	// Convert to Keycloak entity

--- a/core/services/identity_service.go
+++ b/core/services/identity_service.go
@@ -187,6 +187,7 @@ func (s *identityService) SetPIN(ctx context.Context, id string, hashedPIN strin
 
 	// Set PIN in attributes
 	identity.Attributes["pin"] = []string{hashedPIN}
+	identity.Attributes["hasPin"] = []string{"true"}
 
 	// Update in repository
 	_, err = s.identityRepo.UpdateIdentity(ctx, identity)

--- a/core/services/identity_service.go
+++ b/core/services/identity_service.go
@@ -41,6 +41,13 @@ func (s *identityService) CreateIdentity(ctx context.Context, req *requests.Crea
 	log := s.logger.WithContext(ctx)
 	log.Info("Creating new identity", "email", req.Email, "role", req.Role)
 
+	if req.Role != enums.RoleHealthcareProfessional && req.Role != enums.RoleAdmin {
+		if req.GroupID == "" {
+			log.Error("GroupID is required for this role", "role", req.Role)
+			return nil, errors.ErrGroupIDRequired
+		}
+	}
+
 	// Create domain model
 	identity := &models.Identity{
 		Email:     req.Email,

--- a/core/services/identity_service.go
+++ b/core/services/identity_service.go
@@ -95,6 +95,13 @@ func (s *identityService) UpdateRole(ctx context.Context, id string, req *reques
 		return nil, err
 	}
 
+	groupIDValues, hasGroupID := identity.Attributes["groupId"]
+	hasValidGroupID := hasGroupID && len(groupIDValues) > 0 && groupIDValues[0] != ""
+
+	if req.Role != enums.RoleHealthcareProfessional && req.Role != enums.RoleAdmin && !hasValidGroupID {
+		return nil, errors.ErrGroupIDRequired
+	}
+
 	// Update role in attributes
 	identity.Attributes["role"] = []string{string(req.Role)}
 

--- a/domain/entities/keycloak_identity.go
+++ b/domain/entities/keycloak_identity.go
@@ -13,6 +13,8 @@ type KeycloakIdentity struct {
 	Username         string               `json:"username"` // Required by Keycloak
 	Email            string               `json:"email"`
 	Enabled          bool                 `json:"enabled"` // Required by Keycloak
+	FirstName        string               `json:"firstName"`
+	LastName         string               `json:"lastName"`
 	Attributes       map[string][]string  `json:"attributes"`
 	Credentials      []KeycloakCredential `json:"credentials,omitempty"`
 }
@@ -30,19 +32,28 @@ func (ki *KeycloakIdentity) ToModel() *models.Identity {
 		role = enums.Role(roleValues[0])
 	}
 
+	var groupID string
+	if groupValues, exists := ki.Attributes["groupId"]; exists && len(groupValues) > 0 {
+		groupID = groupValues[0]
+	}
+
 	return &models.Identity{
-		ID:    ki.ID,
-		Email: ki.Email,
-		PIN:   pin,
-		Role:  role,
+		ID:        ki.ID,
+		Email:     ki.Email,
+		PIN:       pin,
+		Role:      role,
+		GroupID:   groupID,
+		FirstName: ki.FirstName,
+		LastName:  ki.LastName,
 	}
 }
 
 // FromModel creates a KeycloakIdentity from a domain Identity model
 func FromModel(model *models.Identity, hashedPassword string) *KeycloakIdentity {
 	attributes := map[string][]string{
-		"role":   {string(model.Role)},
-		"hasPin": {strconv.FormatBool(model.PIN != nil)},
+		"role":    {string(model.Role)},
+		"hasPin":  {strconv.FormatBool(model.PIN != nil)},
+		"groupId": {model.GroupID},
 	}
 
 	if model.PIN != nil {
@@ -62,6 +73,8 @@ func FromModel(model *models.Identity, hashedPassword string) *KeycloakIdentity 
 		Username:    model.Email, // Use email as username
 		Email:       model.Email,
 		Enabled:     true, // Always enable users by default
+		FirstName:   model.FirstName,
+		LastName:    model.LastName,
 		Attributes:  attributes,
 		Credentials: credentials,
 	}

--- a/domain/entities/keycloak_identity.go
+++ b/domain/entities/keycloak_identity.go
@@ -3,6 +3,7 @@ package entities
 import (
 	"github.com/PTSS-Support/identity-service/domain/enums"
 	"github.com/PTSS-Support/identity-service/domain/models"
+	"strconv"
 )
 
 // KeycloakIdentity represents the Keycloak user structure
@@ -40,7 +41,8 @@ func (ki *KeycloakIdentity) ToModel() *models.Identity {
 // FromModel creates a KeycloakIdentity from a domain Identity model
 func FromModel(model *models.Identity, hashedPassword string) *KeycloakIdentity {
 	attributes := map[string][]string{
-		"role": {string(model.Role)},
+		"role":   {string(model.Role)},
+		"hasPin": {strconv.FormatBool(model.PIN != nil)},
 	}
 
 	if model.PIN != nil {

--- a/domain/errors/errors.go
+++ b/domain/errors/errors.go
@@ -6,6 +6,7 @@ var (
 	ErrInvalidCredentials = errors.New("invalid credentials")
 	ErrPINAlreadyExists   = errors.New("PIN already exists")
 	ErrNoPINSet           = errors.New("no PIN set")
+	ErrGroupIDRequired    = errors.New("group ID is required for this role")
 
 	ErrInvalidEmail    = errors.New("invalid email")
 	ErrInvalidPassword = errors.New("invalid password")

--- a/domain/models/identity.go
+++ b/domain/models/identity.go
@@ -4,9 +4,12 @@ import "github.com/PTSS-Support/identity-service/domain/enums"
 
 // Identity represents the authentication-specific user data
 type Identity struct {
-	ID       string
-	Email    string
-	Password string
-	PIN      *string
-	Role     enums.Role
+	ID        string
+	Email     string
+	Password  string
+	PIN       *string
+	Role      enums.Role
+	GroupID   string
+	FirstName string
+	LastName  string
 }

--- a/infrastructure/config/config.go
+++ b/infrastructure/config/config.go
@@ -44,7 +44,13 @@ type AuthConfig struct {
 func LoadConfig() (*Config, error) {
 	viper.SetConfigFile(".env")
 	viper.SetConfigType("env")
-
+	// Read the env file
+	err := viper.ReadInConfig()
+	if err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+			return nil, err
+		}
+	}
 	viper.AutomaticEnv()
 
 	accessTokenDuration, _ := strconv.Atoi(viper.GetString("ACCESS_TOKEN_DURATION"))

--- a/infrastructure/config/config.go
+++ b/infrastructure/config/config.go
@@ -42,6 +42,9 @@ type AuthConfig struct {
 }
 
 func LoadConfig() (*Config, error) {
+	viper.SetConfigFile(".env")
+	viper.SetConfigType("env")
+
 	viper.AutomaticEnv()
 
 	accessTokenDuration, _ := strconv.Atoi(viper.GetString("ACCESS_TOKEN_DURATION"))
@@ -52,7 +55,6 @@ func LoadConfig() (*Config, error) {
 	secureRefreshTokenFlag, _ := strconv.ParseBool(viper.GetString("SECURE_REFRESH_TOKEN_FLAG"))
 
 	// Set up direct mappings for env variables
-	viper.AutomaticEnv()
 
 	config := &Config{
 		Server: ServerConfig{

--- a/infrastructure/repositories/base_keycloak_repository.go
+++ b/infrastructure/repositories/base_keycloak_repository.go
@@ -61,7 +61,7 @@ func (r *BaseKeycloakRepository) makeRequest(ctx context.Context, method, url st
 
 func (r *BaseKeycloakRepository) getAdminToken(ctx context.Context) (string, error) {
 	log := r.logger.WithContext(ctx)
-	tokenURL := fmt.Sprintf("%s/realms/%s/protocol/openid-connect/token", r.config.BaseURL, r.config.Realm)
+	tokenURL := fmt.Sprintf("%s/realms/master/protocol/openid-connect/token", r.config.BaseURL)
 
 	data := url.Values{}
 	data.Set("grant_type", "password")

--- a/keycloak-init.sh
+++ b/keycloak-init.sh
@@ -205,7 +205,7 @@ if [ "$CLIENT_EXISTS" = "0" ]; then
 
     # Create required realm roles if they don't exist
     echo "Creating realm roles..."
-    ROLES="manage-users view-users create-user validate-tokens"
+    ROLES="manage-users view-users create-user validate-tokens manage-realm view-realm manage-clients view-clients manage-authorization token-exchange impersonation"
 
     for ROLE in $ROLES; do
         ROLE_EXISTS=$(curl -s -o /dev/null -w "%{http_code}" \
@@ -268,15 +268,20 @@ if [ "$USER_EXISTS" = "0" ]; then
         -H "Authorization: Bearer $TOKEN" \
         -H "Content-Type: application/json" \
         -d '{
-            "username": "'"${KEYCLOAK_REALM_ADMIN_USERNAME}"'",
-            "enabled": true,
-            "credentials": [{
-                "type": "password",
-                "value": "'"${KEYCLOAK_REALM_ADMIN_PASSWORD}"'",
-                "temporary": false
-            }],
-            "realmRoles": ["admin"]
-        }' \
+              "username": "'"${KEYCLOAK_REALM_ADMIN_USERNAME}"'",
+              "enabled": true,
+              "emailVerified": true,
+              "email": "realm_admin@example.com",
+              "firstName": "Realm",
+              "lastName": "Admin",
+              "credentials": [{
+                  "type": "password",
+                  "value": "'"${KEYCLOAK_REALM_ADMIN_PASSWORD}"'",
+                  "temporary": false
+              }],
+              "requiredActions": [],
+              "realmRoles": ["admin manage-users view-users create-user validate-tokens"]
+          }' \
         "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/users"
     # Get the user ID
     USER_ID=$(curl -H "Authorization: Bearer $TOKEN" \

--- a/keycloak-init.sh
+++ b/keycloak-init.sh
@@ -177,6 +177,63 @@ if [ "$CLIENT_EXISTS" = "0" ]; then
         }' \
         "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/client-scopes/${SCOPE_ID}/protocol-mappers/models"
 
+    # Add firstName mapper
+    curl -X POST \
+        -H "Authorization: Bearer $TOKEN" \
+        -H "Content-Type: application/json" \
+        -d '{
+            "name": "first-name",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-property-mapper",
+            "config": {
+                "user.attribute": "firstName",
+                "claim.name": "first_name",
+                "jsonType.label": "String",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "userinfo.token.claim": "true"
+            }
+        }' \
+        "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/client-scopes/${SCOPE_ID}/protocol-mappers/models"
+
+    # Add lastName mapper
+    curl -X POST \
+        -H "Authorization: Bearer $TOKEN" \
+        -H "Content-Type: application/json" \
+        -d '{
+            "name": "last-name",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-property-mapper",
+            "config": {
+                "user.attribute": "lastName",
+                "claim.name": "last_name",
+                "jsonType.label": "String",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "userinfo.token.claim": "true"
+            }
+        }' \
+        "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/client-scopes/${SCOPE_ID}/protocol-mappers/models"
+
+    # Add groupId mapper
+    curl -X POST \
+        -H "Authorization: Bearer $TOKEN" \
+        -H "Content-Type: application/json" \
+        -d '{
+            "name": "group-id",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-attribute-mapper",
+            "config": {
+                "user.attribute": "groupId",
+                "claim.name": "group_id",
+                "jsonType.label": "String",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "userinfo.token.claim": "true"
+            }
+        }' \
+        "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/client-scopes/${SCOPE_ID}/protocol-mappers/models"
+
     # Assign scope to client
     curl -X PUT \
         -H "Authorization: Bearer $TOKEN" \

--- a/keycloak-init.sh
+++ b/keycloak-init.sh
@@ -156,6 +156,27 @@ if [ "$CLIENT_EXISTS" = "0" ]; then
         }' \
         "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/client-scopes/${SCOPE_ID}/protocol-mappers/models"
 
+    # Add hasPin mapper
+    curl -k -X POST \
+        -H "Authorization: Bearer $TOKEN" \
+        -H "Content-Type: application/json" \
+        -d '{
+            "name": "has-pin-mapper",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-attribute-mapper",
+            "config": {
+                "user.attribute": "hasPin",
+                "claim.name": "has_pin",
+                "jsonType.label": "boolean",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "userinfo.token.claim": "true",
+                "access.tokenResponse.claim": "false",
+                "refresh.token.claim": "true"
+            }
+        }' \
+        "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/client-scopes/${SCOPE_ID}/protocol-mappers/models"
+
     # Assign scope to client
     curl -X PUT \
         -H "Authorization: Bearer $TOKEN" \

--- a/openshift/keycloak-init.sh
+++ b/openshift/keycloak-init.sh
@@ -155,6 +155,27 @@ if [ "$CLIENT_EXISTS" = "0" ]; then
         }' \
         "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/client-scopes/${SCOPE_ID}/protocol-mappers/models"
 
+    # Add hasPin mapper
+    curl -k -X POST \
+        -H "Authorization: Bearer $TOKEN" \
+        -H "Content-Type: application/json" \
+        -d '{
+            "name": "has-pin-mapper",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-attribute-mapper",
+            "config": {
+                "user.attribute": "hasPin",
+                "claim.name": "has_pin",
+                "jsonType.label": "boolean",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "userinfo.token.claim": "true",
+                "access.tokenResponse.claim": "false",
+                "refresh.token.claim": "true"
+            }
+        }' \
+        "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/client-scopes/${SCOPE_ID}/protocol-mappers/models"
+
     # Assign scope to client
     curl -k -X PUT \
         -H "Authorization: Bearer $TOKEN" \
@@ -183,7 +204,7 @@ if [ "$CLIENT_EXISTS" = "0" ]; then
 
     # Create required realm roles if they don't exist
     echo "Creating realm roles..."
-    ROLES="manage-users view-users create-user validate-tokens"
+    ROLES="manage-users view-users create-user validate-tokens manage-realm view-realm manage-clients view-clients manage-authorization token-exchange impersonation"
 
     for ROLE in $ROLES; do
         ROLE_EXISTS=$(curl -k -s -o /dev/null -w "%{http_code}" \
@@ -246,15 +267,20 @@ if [ "$USER_EXISTS" = "0" ]; then
         -H "Authorization: Bearer $TOKEN" \
         -H "Content-Type: application/json" \
         -d '{
-            "username": "'"${KEYCLOAK_REALM_ADMIN_USERNAME}"'",
-            "enabled": true,
-            "credentials": [{
-                "type": "password",
-                "value": "'"${KEYCLOAK_REALM_ADMIN_PASSWORD}"'",
-                "temporary": false
-            }],
-            "realmRoles": ["admin"]
-        }' \
+               "username": "'"${KEYCLOAK_REALM_ADMIN_USERNAME}"'",
+               "enabled": true,
+               "emailVerified": true,
+               "email": "realm_admin@example.com",
+               "firstName": "Realm",
+               "lastName": "Admin",
+               "credentials": [{
+                   "type": "password",
+                   "value": "'"${KEYCLOAK_REALM_ADMIN_PASSWORD}"'",
+                   "temporary": false
+               }],
+               "requiredActions": [],
+               "realmRoles": ["admin manage-users view-users create-user validate-tokens"]
+           }' \
         "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/users"
     # Get the user ID
     USER_ID=$(curl -k -H "Authorization: Bearer $TOKEN" \

--- a/openshift/keycloak.yaml
+++ b/openshift/keycloak.yaml
@@ -12,5 +12,33 @@ spec:
   additionalOptions:
     - name: FEATURES
       value: 'hostname:v2'
+    - name: PROXY
+      value: edge
+    - name: PROXY_ADDRESS_FORWARDING
+      value: 'true'
     - name: PROXY_HEADERS
       value: xforwarded
+    - name: HEALTH_ENABLED
+      value: 'true'
+    - name: LEGACY-OBSERVABILITY-INTERFACE
+      value: 'true'
+  unsupported:
+    podTemplate:
+      spec:
+        containers:
+          - livenessProbe:
+              httpGet:
+                path: /health/live
+                port: 8080
+                scheme: HTTP
+            name: keycloak
+            readinessProbe:
+              httpGet:
+                path: /health/ready
+                port: 8080
+                scheme: HTTP
+            startupProbe:
+              httpGet:
+                path: /health/started
+                port: 8080
+                scheme: HTTP

--- a/openshift/test-keycloak.sh
+++ b/openshift/test-keycloak.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+set -e
+
+# Load environment variables
+if [ -f .env ]; then
+    export $(cat .env | grep -v '^#' | xargs)
+else
+    echo "Error: .env file not found"
+    exit 1
+fi
+
+echo "1. Getting admin token..."
+TOKEN=$(curl -k -d "client_id=${KEYCLOAK_ADMIN_CLIENT_ID}" \
+    -d "username=${KEYCLOAK_ADMIN_USERNAME}" \
+    -d "password=${KEYCLOAK_ADMIN_PASSWORD}" \
+    -d "grant_type=password" \
+    "${KEYCLOAK_BASE_URL}/realms/master/protocol/openid-connect/token" | jq -r '.access_token')
+
+if [ -z "$TOKEN" ]; then
+    echo "Error: Failed to obtain admin token"
+    exit 1
+else
+    echo "✓ Admin token obtained successfully"
+fi
+
+echo -e "\n2. Getting realm_admin user ID..."
+USER_ID=$(curl -k -H "Authorization: Bearer $TOKEN" \
+    "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/users?username=${KEYCLOAK_REALM_ADMIN_USERNAME}" \
+    | jq -r '.[0].id')
+
+if [ -z "$USER_ID" ]; then
+    echo "Error: Could not find realm_admin user"
+    exit 1
+else
+    echo "✓ Found realm_admin user with ID: $USER_ID"
+fi
+
+echo -e "\n3. Checking realm_admin roles..."
+echo "Current roles assigned to realm_admin:"
+curl -k -H "Authorization: Bearer $TOKEN" \
+    "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/users/${USER_ID}/role-mappings/realm/composite" | jq -r '.[].name' | while read -r role; do
+    echo "✓ Has role: $role"
+done
+
+echo -e "\n4. Testing realm_admin authentication..."
+REALM_ADMIN_TOKEN=$(curl -k -d "client_id=${KEYCLOAK_CLIENT_ID}" \
+    -d "client_secret=${KEYCLOAK_CLIENT_SECRET}" \
+    -d "username=${KEYCLOAK_REALM_ADMIN_USERNAME}" \
+    -d "password=${KEYCLOAK_REALM_ADMIN_PASSWORD}" \
+    -d "grant_type=password" \
+    "${KEYCLOAK_BASE_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token" | jq -r '.access_token')
+
+if [ -z "$REALM_ADMIN_TOKEN" ]; then
+    echo "Error: Failed to obtain realm_admin token"
+    exit 1
+else
+    echo "✓ Successfully authenticated as realm_admin"
+fi
+
+echo -e "\n5. Testing token introspection..."
+INTROSPECTION_RESULT=$(curl -k -X POST \
+    -d "token=${REALM_ADMIN_TOKEN}" \
+    -d "client_id=${KEYCLOAK_CLIENT_ID}" \
+    -d "client_secret=${KEYCLOAK_CLIENT_SECRET}" \
+    "${KEYCLOAK_BASE_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token/introspect" | jq -r '.active')
+
+if [ "$INTROSPECTION_RESULT" = "true" ]; then
+    echo "✓ Token introspection successful"
+else
+    echo "Error: Token introspection failed"
+fi
+
+echo -e "\n6. Testing user management..."
+echo "Creating test user..."
+TEST_USER_RESPONSE=$(curl -k -X POST \
+    -H "Authorization: Bearer ${REALM_ADMIN_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d '{
+        "username": "testuser",
+        "enabled": true,
+        "credentials": [{
+            "type": "password",
+            "value": "test123",
+            "temporary": false
+        }]
+    }' \
+    -w "%{http_code}" \
+    "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/users")
+
+if [ "$TEST_USER_RESPONSE" = "201" ] || [ "$TEST_USER_RESPONSE" = "409" ]; then
+    echo "✓ User creation test passed (created or already exists)"
+else
+    echo "Error: Failed to create test user"
+fi
+
+echo "Retrieving test user..."
+TEST_USER_GET=$(curl -k -H "Authorization: Bearer ${REALM_ADMIN_TOKEN}" \
+    "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/users?username=testuser" | jq '. | length')
+
+if [ "$TEST_USER_GET" -gt 0 ]; then
+    echo "✓ Successfully retrieved test user"
+else
+    echo "Error: Could not retrieve test user"
+fi
+
+echo -e "\n7. Testing token refresh..."
+echo "Getting fresh tokens..."
+TOKEN_RESPONSE=$(curl -k -d "client_id=${KEYCLOAK_CLIENT_ID}" \
+    -d "client_secret=${KEYCLOAK_CLIENT_SECRET}" \
+    -d "username=${KEYCLOAK_REALM_ADMIN_USERNAME}" \
+    -d "password=${KEYCLOAK_REALM_ADMIN_PASSWORD}" \
+    -d "grant_type=password" \
+    "${KEYCLOAK_BASE_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token")
+
+REFRESH_TOKEN=$(echo $TOKEN_RESPONSE | jq -r '.refresh_token')
+
+if [ -z "$REFRESH_TOKEN" ] || [ "$REFRESH_TOKEN" = "null" ]; then
+    echo "Error: Failed to obtain refresh token"
+    exit 1
+else
+    echo "✓ Obtained refresh token"
+fi
+
+echo "Testing token refresh..."
+REFRESH_RESPONSE=$(curl -k -X POST \
+    -d "client_id=${KEYCLOAK_CLIENT_ID}" \
+    -d "client_secret=${KEYCLOAK_CLIENT_SECRET}" \
+    -d "grant_type=refresh_token" \
+    -d "refresh_token=${REFRESH_TOKEN}" \
+    "${KEYCLOAK_BASE_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token" | jq -r '.access_token')
+
+if [ -n "$REFRESH_RESPONSE" ] && [ "$REFRESH_RESPONSE" != "null" ]; then
+    echo "✓ Successfully refreshed token"
+else
+    echo "Error: Failed to refresh token"
+fi
+
+echo -e "\n8. Cleanup..."
+echo "Removing test user..."
+TEST_USER_ID=$(curl -k -H "Authorization: Bearer ${REALM_ADMIN_TOKEN}" \
+    "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/users?username=testuser" | jq -r '.[0].id')
+
+if [ -n "$TEST_USER_ID" ] && [ "$TEST_USER_ID" != "null" ]; then
+    curl -k -X DELETE \
+        -H "Authorization: Bearer ${REALM_ADMIN_TOKEN}" \
+        "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/users/${TEST_USER_ID}"
+    echo "✓ Test user removed"
+else
+    echo "Warning: Could not find test user to remove"
+fi
+
+echo -e "\nPermission verification complete!"


### PR DESCRIPTION
### **READ TEXT FOR CONTEXT**

For future reference, the access token looks like this:
```
{
  "exp": 1736023776,
  "iat": 1736023476,
  "jti": "841f6c79-ebcc-42d3-996e-404bc7e7995c",
  "iss": "http://localhost:8080/realms/ptss-support",
  "sub": "997187d2-383b-4745-a3aa-c140ca251e90",
  "typ": "Bearer",
  "azp": "authentication-service",
  "session_state": "380bc104-f97e-4f7e-b02c-b7d444747d82",
  "acr": "1",
  "allowed-origins": [
    "*"
  ],
  "scope": "openid user-details",
  "sid": "380bc104-f97e-4f7e-b02c-b7d444747d82",
  "user_id": "997187d2-383b-4745-a3aa-c140ca251e90",
  "group_id": "95b064c3-897a-48c7-acdd-10bbe1778312",
  "roles": [
    "patient",
    "offline_access",
    "default-roles-ptss-support",
    "uma_authorization"
  ],
  "last_name": "Dersjant",
  "first_name": "Frank",
  "has_pin": false
}
```

So this pr actually has multiple features. So first of all, this has added not only the has_pin, but also groupId, firstName and lastName to access token.
This was not added to the refresh token because of how OAuth2.0 structured their recommendation, the refresh token must stay opaque, business logic must be in the access token, so keycloak didn't bother with adding methods for adding attributes and mappers to their refresh token, so this is the workaround Sem and I chose.
config.go changed to make it work for both local and deployment containers (last one needs to be tested). Deployment containers need automaticEnv, locally i need `viper.SetConfigFile(".env")` and `viper.SetConfigType("env")`

keycloak deployment now works with tls, and is setup correctly for future actions, thus changes of those which i did not push yet were added here. You can ignore these as they're mostly tested and working.

keycloak init has a has_pin added, also added more realm admin focussed users, so that actually can take over some of the workload wherever applicable, before this gave errors, now fixed.

keycloak.yaml has:
```
  unsupported:
    podTemplate:
      spec:
        containers:
          - livenessProbe:
              httpGet:
                path: /health/live
                port: 8080
                scheme: HTTP
            name: keycloak
            readinessProbe:
              httpGet:
                path: /health/ready
                port: 8080
                scheme: HTTP
            startupProbe:
              httpGet:
                path: /health/started
                port: 8080
                scheme: HTTP
```
because otherwise it would point to 9000 management port, which is unreachable by other containers on dev environment, causing the authentication service to say keycloak is down when it really isn't.