### PR TITLE
updated the keycloak locally and the code to make this work

### DIFF
--- a/core/services/identity_service.go
+++ b/core/services/identity_service.go
@@ -74,18 +74,11 @@ func (s *identityService) CreateIdentity(ctx context.Context, req *requests.Crea
 
 	log.Debug("Successfully created identity in Keycloak", "id", createdIdentity.ID)
 
-	// Extract role from attributes
-	var role enums.Role
-	if roleValues, exists := createdIdentity.Attributes["role"]; exists && len(roleValues) > 0 {
-		role = enums.Role(roleValues[0])
-		log.Debug("Extracted role from attributes", "role", role)
-	}
-
 	// Convert to response
 	response := &responses.IdentityResponse{
 		ID:    createdIdentity.ID,
 		Email: createdIdentity.Email,
-		Role:  role,
+		Role:  req.Role,
 	}
 	log.Info("Successfully created identity", "id", response.ID, "email", response.Email)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,22 +19,29 @@ services:
       - keycloak-network
 
   keycloak:
-    image: quay.io/keycloak/keycloak:22.0
+    image: quay.io/keycloak/keycloak:26.0.7
     container_name: keycloak
     environment:
       KC_DB: postgres
-      KC_DB_URL: jdbc:postgresql://postgres:5432/keycloak
+      KC_DB_URL_HOST: postgres
+      KC_DB_URL_PORT: 5432
+      KC_DB_URL_DATABASE: keycloak
       KC_DB_USERNAME: keycloak
       KC_DB_PASSWORD: keycloak_password
+      KC_HEALTH_ENABLED: "true"
+      KC_HTTP_ENABLED: "true"
+      KC_HOSTNAME_STRICT: "false"
+      KC_HOSTNAME_STRICT_HTTPS: "false"
+      KC_LEGACY_OBSERVABILITY_INTERFACE: "true"
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
-      KC_HEALTH_ENABLED: "true"
+
     ports:
       - "8080:8080"
     depends_on:
       postgres:
         condition: service_healthy
-    command: ["start-dev"]
+    command: start-dev
     healthcheck:
       test: [ "CMD", "/opt/keycloak/bin/kc.sh", "show-config" ]
       interval: 30s

--- a/infrastructure/repositories/identity_repository.go
+++ b/infrastructure/repositories/identity_repository.go
@@ -109,6 +109,34 @@ func (r *identityRepository) GetIdentity(ctx context.Context, id string) (*entit
 		return nil, err
 	}
 
+	roles, err := r.GetUserRoles(ctx, id)
+	if err != nil {
+		log.Error("Failed to get user roles", "error", err)
+		return nil, err
+	}
+
+	if identity.Attributes == nil {
+		identity.Attributes = make(map[string][]string)
+	}
+
+	if len(roles) > 0 {
+		identity.Attributes["role"] = []string{roles[0]} // Use first role as main role
+	}
+
+	requiredAttributes := []string{"role", "groupId", "hasPin"}
+	for _, attr := range requiredAttributes {
+		if _, exists := identity.Attributes[attr]; !exists {
+			identity.Attributes[attr] = []string{""}
+		}
+	}
+
+	log.Debug("Completed identity fetch",
+		"id", identity.ID,
+		"email", identity.Email,
+		"role", identity.Attributes["role"],
+		"groupId", identity.Attributes["groupId"],
+		"hasPin", identity.Attributes["hasPin"])
+
 	return &identity, nil
 }
 
@@ -343,4 +371,45 @@ func (r *identityRepository) handleNonSuccessResponse(resp *http.Response) error
 
 func (r *identityRepository) extractUserIDFromLocation(location string) string {
 	return location[strings.LastIndex(location, "/")+1:]
+}
+
+func (r *identityRepository) GetUserRoles(ctx context.Context, userID string) ([]string, error) {
+	token, err := r.getAdminToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	roleURL := fmt.Sprintf("%s/admin/realms/%s/users/%s/role-mappings/realm",
+		r.config.BaseURL, r.config.Realm, userID)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", roleURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get user roles: %d", resp.StatusCode)
+	}
+
+	var roles []map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&roles); err != nil {
+		return nil, err
+	}
+
+	var roleNames []string
+	for _, role := range roles {
+		if name, ok := role["name"].(string); ok {
+			roleNames = append(roleNames, name)
+		}
+	}
+
+	return roleNames, nil
 }

--- a/infrastructure/repositories/identity_repository.go
+++ b/infrastructure/repositories/identity_repository.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/PTSS-Support/identity-service/domain/enums"
 	"io"
 	"net/http"
 	"net/url"
@@ -43,16 +42,6 @@ func (r *identityRepository) CreateIdentity(ctx context.Context, identity *entit
 	userID, err := r.createKeycloakUser(ctx, identity)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create keycloak user: %w", err)
-	}
-
-	roleValues, exists := identity.Attributes["role"]
-	if !exists || len(roleValues) == 0 {
-		return nil, fmt.Errorf("role not found in identity attributes")
-	}
-	role := enums.Role(roleValues[0])
-
-	if err := r.assignUserRole(ctx, userID, role); err != nil {
-		return nil, fmt.Errorf("failed to assign role to user: %w", err)
 	}
 
 	return r.GetIdentity(ctx, userID)
@@ -108,34 +97,6 @@ func (r *identityRepository) GetIdentity(ctx context.Context, id string) (*entit
 			"response", string(body))
 		return nil, err
 	}
-
-	roles, err := r.GetUserRoles(ctx, id)
-	if err != nil {
-		log.Error("Failed to get user roles", "error", err)
-		return nil, err
-	}
-
-	if identity.Attributes == nil {
-		identity.Attributes = make(map[string][]string)
-	}
-
-	if len(roles) > 0 {
-		identity.Attributes["role"] = []string{roles[0]} // Use first role as main role
-	}
-
-	requiredAttributes := []string{"role", "groupId", "hasPin"}
-	for _, attr := range requiredAttributes {
-		if _, exists := identity.Attributes[attr]; !exists {
-			identity.Attributes[attr] = []string{""}
-		}
-	}
-
-	log.Debug("Completed identity fetch",
-		"id", identity.ID,
-		"email", identity.Email,
-		"role", identity.Attributes["role"],
-		"groupId", identity.Attributes["groupId"],
-		"hasPin", identity.Attributes["hasPin"])
 
 	return &identity, nil
 }
@@ -310,56 +271,6 @@ func (r *identityRepository) createKeycloakUser(ctx context.Context, identity *e
 	return userID, nil
 }
 
-func (r *identityRepository) assignUserRole(ctx context.Context, userID string, role enums.Role) error {
-	roleInfo, err := r.getRoleInfo(ctx, role)
-	if err != nil {
-		return fmt.Errorf("failed to get role info: %w", err)
-	}
-
-	roleURL := fmt.Sprintf("%s/admin/realms/%s/users/%s/role-mappings/realm",
-		r.config.BaseURL, r.config.Realm, userID)
-	roleAssignment := []map[string]interface{}{
-		{
-			"id":   roleInfo["id"],
-			"name": strings.ToLower(string(role)),
-		},
-	}
-
-	resp, err := r.makeJSONRequest(ctx, "POST", roleURL, roleAssignment)
-	if err != nil {
-		return fmt.Errorf("failed to assign role: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusNoContent {
-		return r.handleNonSuccessResponse(resp)
-	}
-
-	return nil
-}
-
-func (r *identityRepository) getRoleInfo(ctx context.Context, role enums.Role) (map[string]interface{}, error) {
-	roleInfoURL := fmt.Sprintf("%s/admin/realms/%s/roles/%s",
-		r.config.BaseURL, r.config.Realm, strings.ToLower(string(role)))
-
-	resp, err := r.makeJSONRequest(ctx, "GET", roleInfoURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get role info: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, r.handleNonSuccessResponse(resp)
-	}
-
-	var roleInfo map[string]interface{}
-	if err := json.NewDecoder(resp.Body).Decode(&roleInfo); err != nil {
-		return nil, fmt.Errorf("failed to decode role info: %w", err)
-	}
-
-	return roleInfo, nil
-}
-
 func (r *identityRepository) handleNonSuccessResponse(resp *http.Response) error {
 	body, _ := io.ReadAll(resp.Body)
 	r.logger.Error("Received non-success status from Keycloak",
@@ -371,45 +282,4 @@ func (r *identityRepository) handleNonSuccessResponse(resp *http.Response) error
 
 func (r *identityRepository) extractUserIDFromLocation(location string) string {
 	return location[strings.LastIndex(location, "/")+1:]
-}
-
-func (r *identityRepository) GetUserRoles(ctx context.Context, userID string) ([]string, error) {
-	token, err := r.getAdminToken(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	roleURL := fmt.Sprintf("%s/admin/realms/%s/users/%s/role-mappings/realm",
-		r.config.BaseURL, r.config.Realm, userID)
-
-	req, err := http.NewRequestWithContext(ctx, "GET", roleURL, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Authorization", "Bearer "+token)
-
-	resp, err := r.httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to get user roles: %d", resp.StatusCode)
-	}
-
-	var roles []map[string]interface{}
-	if err := json.NewDecoder(resp.Body).Decode(&roles); err != nil {
-		return nil, err
-	}
-
-	var roleNames []string
-	for _, role := range roles {
-		if name, ok := role["name"].(string); ok {
-			roleNames = append(roleNames, name)
-		}
-	}
-
-	return roleNames, nil
 }

--- a/keycloak-init.sh
+++ b/keycloak-init.sh
@@ -76,6 +76,143 @@ if [ "$REALM_EXISTS" = "404" ]; then
               "accessTokenLifespanForImplicitFlow":1200
                 }' \
         "${KEYCLOAK_BASE_URL}/admin/realms"
+
+    echo "Configuring user profile attributes..."
+        # shellcheck disable=SC2016
+    curl -X PUT \
+        -H "Authorization: Bearer $TOKEN" \
+        -H "Content-Type: application/json" \
+        -d '{
+                  "attributes": [
+                      {
+                          "name": "username",
+                          "displayName": "${username}",
+                          "validations": {
+                              "length": {
+                                  "min": 3,
+                                  "max": 255
+                              },
+                              "username-prohibited-characters": {},
+                              "up-username-not-idn-homograph": {}
+                          },
+                          "permissions": {
+                              "view": ["admin"],
+                              "edit": ["admin", "user"]
+                          },
+                          "multivalued": false
+                      },
+                      {
+                          "name": "email",
+                          "displayName": "${email}",
+                          "validations": {
+                              "email": {},
+                              "length": {
+                                  "max": 255
+                              }
+                          },
+                          "required": {
+                              "roles": ["user"]
+                          },
+                          "permissions": {
+                              "view": ["admin"],
+                              "edit": ["admin", "user"]
+                          },
+                          "multivalued": false
+                      },
+                      {
+                          "name": "firstName",
+                          "displayName": "${firstName}",
+                          "validations": {
+                              "length": {
+                                  "max": 255
+                              },
+                              "person-name-prohibited-characters": {}
+                          },
+                          "required": {
+                              "roles": ["user"]
+                          },
+                          "permissions": {
+                              "view": ["admin", "user"],
+                              "edit": ["admin", "user"]
+                          },
+                          "multivalued": false
+                      },
+                      {
+                          "name": "lastName",
+                          "displayName": "${lastName}",
+                          "validations": {
+                              "length": {
+                                  "max": 255
+                              },
+                              "person-name-prohibited-characters": {}
+                          },
+                          "required": {
+                              "roles": ["user"]
+                          },
+                          "permissions": {
+                              "view": ["admin", "user"],
+                              "edit": ["admin", "user"]
+                          },
+                          "multivalued": false
+                      },
+                      {
+                          "name": "groupId",
+                          "displayName": "group id",
+                          "permissions": {
+                              "edit": ["admin", "user"],
+                              "view": ["user", "admin"]
+                          },
+                          "multivalued": false,
+                          "annotations": {},
+                          "validations": {}
+                      },
+                      {
+                          "name": "role",
+                          "displayName": "Role",
+                          "permissions": {
+                              "edit": ["admin"],
+                              "view": ["user", "admin"]
+                          },
+                          "multivalued": false,
+                          "annotations": {},
+                          "validations": {
+                              "length": { "min": 1, "max": 255 }
+                          }
+                      },
+                      {
+                          "name": "hasPin",
+                          "displayName": "Has PIN",
+                          "permissions": {
+                              "edit": ["admin", "user"],
+                              "view": ["user", "admin"]
+                          },
+                          "multivalued": false,
+                          "annotations": {},
+                          "validations": {}
+                      },
+                      {
+                          "name": "pin",
+                          "displayName": "PIN",
+                          "permissions": {
+                              "edit": ["admin", "user"],
+                              "view": ["user", "admin"]
+                          },
+                          "multivalued": false,
+                          "annotations": {},
+                          "validations": {
+                              "length": { "min": 1, "max": 255 }
+                          }
+                      }
+                  ],
+                  "groups": [
+                      {
+                          "name": "user-metadata",
+                          "displayHeader": "User metadata",
+                          "displayDescription": "Attributes, which refer to user metadata"
+                      }
+                  ]
+              }'  \
+        "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/users/profile"
 else
     echo "Realm already exists, skipping creation..."
 fi

--- a/openshift/keycloak-init.sh
+++ b/openshift/keycloak-init.sh
@@ -78,6 +78,143 @@ if [ "$REALM_EXISTS" = "404" ]; then
               "accessTokenLifespanForImplicitFlow":1200
                 }' \
         "${KEYCLOAK_BASE_URL}/admin/realms"
+
+    echo "Configuring user profile attributes..."
+    # shellcheck disable=SC2016
+    curl -X PUT \
+        -H "Authorization: Bearer $TOKEN" \
+        -H "Content-Type: application/json" \
+        -d '{
+                  "attributes": [
+                      {
+                          "name": "username",
+                          "displayName": "${username}",
+                          "validations": {
+                              "length": {
+                                  "min": 3,
+                                  "max": 255
+                              },
+                              "username-prohibited-characters": {},
+                              "up-username-not-idn-homograph": {}
+                          },
+                          "permissions": {
+                              "view": ["admin"],
+                              "edit": ["admin", "user"]
+                          },
+                          "multivalued": false
+                      },
+                      {
+                          "name": "email",
+                          "displayName": "${email}",
+                          "validations": {
+                              "email": {},
+                              "length": {
+                                  "max": 255
+                              }
+                          },
+                          "required": {
+                              "roles": ["user"]
+                          },
+                          "permissions": {
+                              "view": ["admin"],
+                              "edit": ["admin", "user"]
+                          },
+                          "multivalued": false
+                      },
+                      {
+                          "name": "firstName",
+                          "displayName": "${firstName}",
+                          "validations": {
+                              "length": {
+                                  "max": 255
+                              },
+                              "person-name-prohibited-characters": {}
+                          },
+                          "required": {
+                              "roles": ["user"]
+                          },
+                          "permissions": {
+                              "view": ["admin", "user"],
+                              "edit": ["admin", "user"]
+                          },
+                          "multivalued": false
+                      },
+                      {
+                          "name": "lastName",
+                          "displayName": "${lastName}",
+                          "validations": {
+                              "length": {
+                                  "max": 255
+                              },
+                              "person-name-prohibited-characters": {}
+                          },
+                          "required": {
+                              "roles": ["user"]
+                          },
+                          "permissions": {
+                              "view": ["admin", "user"],
+                              "edit": ["admin", "user"]
+                          },
+                          "multivalued": false
+                      },
+                      {
+                          "name": "groupId",
+                          "displayName": "group id",
+                          "permissions": {
+                              "edit": ["admin", "user"],
+                              "view": ["user", "admin"]
+                          },
+                          "multivalued": false,
+                          "annotations": {},
+                          "validations": {}
+                      },
+                      {
+                          "name": "role",
+                          "displayName": "Role",
+                          "permissions": {
+                              "edit": ["admin"],
+                              "view": ["user", "admin"]
+                          },
+                          "multivalued": false,
+                          "annotations": {},
+                          "validations": {
+                              "length": { "min": 1, "max": 255 }
+                          }
+                      },
+                      {
+                          "name": "hasPin",
+                          "displayName": "Has PIN",
+                          "permissions": {
+                              "edit": ["admin", "user"],
+                              "view": ["user", "admin"]
+                          },
+                          "multivalued": false,
+                          "annotations": {},
+                          "validations": {}
+                      },
+                      {
+                          "name": "pin",
+                          "displayName": "PIN",
+                          "permissions": {
+                              "edit": ["admin", "user"],
+                              "view": ["user", "admin"]
+                          },
+                          "multivalued": false,
+                          "annotations": {},
+                          "validations": {
+                              "length": { "min": 1, "max": 255 }
+                          }
+                      }
+                  ],
+                  "groups": [
+                      {
+                          "name": "user-metadata",
+                          "displayHeader": "User metadata",
+                          "displayDescription": "Attributes, which refer to user metadata"
+                      }
+                  ]
+              }'  \
+        "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/users/profile"
 else
     echo "Realm already exists, skipping creation..."
 fi

--- a/openshift/keycloak-init.sh
+++ b/openshift/keycloak-init.sh
@@ -32,7 +32,7 @@ check_required_var "KEYCLOAK_REALM_ADMIN_PASSWORD"
 if [ "$USE_DOCKER" = "true" ]; then
     KEYCLOAK_BASE_URL="http://keycloak:8080"
     echo "Running in Docker mode, using URL: ${KEYCLOAK_BASE_URL}"
-    until curl -k -f "${KEYCLOAK_BASE_URL}/health/ready"; do
+    until curl -k -f "http://keycloak:9000/health/ready"; do
         echo "Trying to connect to Keycloak at: ${KEYCLOAK_BASE_URL}/health/ready"
         echo "Waiting for Keycloak to start..."
         sleep 5
@@ -160,6 +160,63 @@ if [ "$CLIENT_EXISTS" = "0" ]; then
             "config": {
                 "multivalued": "true",
                 "claim.name": "roles",
+                "jsonType.label": "String",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "userinfo.token.claim": "true"
+            }
+        }' \
+        "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/client-scopes/${SCOPE_ID}/protocol-mappers/models"
+
+    # Add firstName mapper
+    curl -k -X POST \
+        -H "Authorization: Bearer $TOKEN" \
+        -H "Content-Type: application/json" \
+        -d '{
+            "name": "first-name",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-property-mapper",
+            "config": {
+                "user.attribute": "firstName",
+                "claim.name": "first_name",
+                "jsonType.label": "String",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "userinfo.token.claim": "true"
+            }
+        }' \
+        "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/client-scopes/${SCOPE_ID}/protocol-mappers/models"
+
+    # Add lastName mapper
+    curl -k -X POST \
+        -H "Authorization: Bearer $TOKEN" \
+        -H "Content-Type: application/json" \
+        -d '{
+            "name": "last-name",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-property-mapper",
+            "config": {
+                "user.attribute": "lastName",
+                "claim.name": "last_name",
+                "jsonType.label": "String",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "userinfo.token.claim": "true"
+            }
+        }' \
+        "${KEYCLOAK_BASE_URL}/admin/realms/${KEYCLOAK_REALM}/client-scopes/${SCOPE_ID}/protocol-mappers/models"
+
+    # Add groupId mapper
+    curl -k -X POST \
+        -H "Authorization: Bearer $TOKEN" \
+        -H "Content-Type: application/json" \
+        -d '{
+            "name": "group-id",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-attribute-mapper",
+            "config": {
+                "user.attribute": "groupId",
+                "claim.name": "group_id",
                 "jsonType.label": "String",
                 "id.token.claim": "true",
                 "access.token.claim": "true",


### PR DESCRIPTION
why on gods green earth would keycloak when doing a major update;
1. remove ui elements from their GUI, because 'it streamlines the user experience☝️🤓' making me think the implementation of my old code doesn't work as custom attributes were COMPLETELY REMOVED FROM THEIR GUI, MAKING IT IMPOSSIBLE TO SEE IF ANYONE HAS ANY CUSTOM ROLES. I AM NOT THE ONLY ONE HAVING THIS ISSUE, SEE THIS GUY WHO ALSO HAS NO CLUE AND ITS UNANSWERED https://stackoverflow.com/questions/79335281/how-to-define-custom-user-attributes-in-keycloak-26s-realm-user-profile-via-the . KEYCLOAK ONLY KEPT THEIR STANDARD ATTRIBUTES, WHICH MAKE NO SENSE
1.5. I FOUND OUT THEY MOVED EEEEEVERYTHING TO THE STANDARD ATTRIBUTES, THE ONLY WAY TO ALSO UPDATE THE STANDARD ATTRIBUTES IS BY SENDING A PUT REQUEST, MEANING THAT EVERY ATTRIBUTE YOU NOW WANT TO ADD HAS TO HAVE ALL THE PREVIOUS ATTRIBUTES ON TOP OF IT, BECAUSE APPARENTLY MAKING A POST REQUEST WAS TOO MUCH WORK 
2. ADD TEMP_USERS, BUT MAKE IT SO THEIR CODE DOES NOT WORK OR THEIR DOCUMENTATION IS OUTDATED, AS SETTING THE ENV VARIABLE TO       KC_BOOTSTRAP_ADMIN_PASSWORD: admin DOES NOTHING, BUT THEY WARN OF USING THEIR DEPRICATED KEYCLOAK_ADMIN, ALTHROUGH ONLY THAT WORKS.
3. MAKE IT SO WHEN GETTING THE USER, YOU CAN'T EVEN GET YOUR ROLES IN THE OLD REQUEST!? WHY?? 
4. WHY CAN I SEND ATTRIBUTES THAT APPRANTLY DON'T GET SET IN KEYCLOAK, AS YOU NEED TO FIRST CREATE A NEW 'STANDARD ATTRIBUTE' THROUGH THEIR DUMB PUT REQUEST


all in all 10/10 would use keycloak again

anyways this is done because the keycloak operator was running on version 26.0.7, i thought ah maybe i can downgrade it. no. Frank removed all our rights for the operator, so we're stuck on version 26.0.7. That version, as you can read above, made some core features not work anymore, this pr is made out of the sweat and tears i have shed for figuring out what the optimal solution was.
